### PR TITLE
device/arm: clear pending interrupts before enabling them

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -43,8 +43,8 @@ func TestBinarySize(t *testing.T) {
 	tests := []sizeTest{
 		// microcontrollers
 		{"hifive1b", "examples/echo", 4560, 280, 0, 2268},
-		{"microbit", "examples/serial", 2916, 388, 8, 2272},
-		{"wioterminal", "examples/pininterrupt", 7359, 1489, 116, 6912},
+		{"microbit", "examples/serial", 2924, 388, 8, 2272},
+		{"wioterminal", "examples/pininterrupt", 7383, 1489, 116, 6912},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/src/device/arm/arm.go
+++ b/src/device/arm/arm.go
@@ -146,6 +146,11 @@ const (
 	SYST_CALIB_NOREF     = 0x80000000 // Bit NOREF.
 )
 
+// ClearPendingIRQ clears the pending status of the interrupt.
+func ClearPendingIRQ(irq uint32) {
+	NVIC.ICPR[irq>>5].Set(1 << (irq & 0x1F))
+}
+
 // Enable the given interrupt number.
 func EnableIRQ(irq uint32) {
 	NVIC.ISER[irq>>5].Set(1 << (irq & 0x1F))

--- a/src/runtime/interrupt/interrupt_cortexm.go
+++ b/src/runtime/interrupt/interrupt_cortexm.go
@@ -9,6 +9,9 @@ import (
 // Enable enables this interrupt. Right after calling this function, the
 // interrupt may be invoked if it was already pending.
 func (irq Interrupt) Enable() {
+	// Clear the ARM pending bit, an asserting device may still
+	// trigger the interrupt once enabled.
+	arm.ClearPendingIRQ(uint32(irq.num))
 	arm.EnableIRQ(uint32(irq.num))
 }
 


### PR DESCRIPTION
Without this change, a pending interrupt would spuriously trigger immediately after enabling. This happens if an interrupt is triggered during flashing (e.g. by DMA), which survives the subsequent reset.

This behaviour matches e.g. `machine.irqSet` in machine_rp2_rp2350.go.

See 7f970a45, whose symptoms were likely caused by spurious interrupts.